### PR TITLE
Preparação do README para orientar as pessoas a baixar a tradução via GitHub Releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@
 
 ## Links
 
-### 💻 [Baixar Tradução (Capítulos 2 e 1)](https://twitter.com/deltarune_br)
-**O link te redirecionará ao Twitter do DELTARUNE BRASIL**, a versão mais recente tradução estará sempre disponível lá! Note que os arquivos apenas contém os arquivos da tradução, e não o jogo em sí, você terá que baixar o jogo pela [Steam](https://store.steampowered.com/app/1671210/DELTARUNE/) ou [Itch.io](https://tobyfox.itch.io/deltarune) e substituir os arquivos do jogo.
+### 💻 [Baixar Tradução (Capítulos 1 e 2)](https://github.com/gomaproi/deltarune-ptbr/releases/latest)
+
+**O link te redirecionará à nossa publicação mais recente da tradução dos capítulos 1 e 2.** Quer baixar uma versão mais antiga? Dê uma olhada na nossa [página de publicações](https://github.com/gomaproi/deltarune-ptbr/releases)! Note que os arquivos apenas contém os arquivos da tradução, e não o jogo em si. Você terá que baixar o jogo pela [Steam](https://store.steampowered.com/app/1671210/DELTARUNE/) ou [Itch.io](https://tobyfox.itch.io/deltarune) e substituir os arquivos do jogo.
 
 ### 📞 [Entrar no nosso Discord](https://discord.gg/7DtZ7E4yYG)
-**Com dúvidas na instalação? Entre no nosso servidor Discord** para receber ajuda na instalação! O servidor é gerenciado pela TEIARRUMA, e não tem nenhuma relação com a CÓRTEX ou NANALUKI.
+
+**Com dúvidas na instalação? Quer reportar erros? Entre no nosso servidor Discord!** O servidor é gerenciado pela TEIARRUMA e não tem nenhuma relação com a CÓRTEX ou NANALUKI.
 
 ## Créditos (Capítulo 2)
 - **Nanaluki** - Tradução / Gráficos / Revisão / Coordenação;


### PR DESCRIPTION
Mesmo que não haja nenhuma tradução do capítulo 2 publicada nas releases do repositório no momento, antecipei o trabalho de mudar o README do repositório a fim de parar de redirecionar o link de download para a página \@deltarune_br no Twitter e passar a redirecionar para as releases do repositório. Esse será o local em que nós, Teiarruma, publicaremos versões antigas e novas da tradução.